### PR TITLE
Fixed async waterfall example in Notes

### DIFF
--- a/src/documents/articles/12-doing-things-in-series.html.md
+++ b/src/documents/articles/12-doing-things-in-series.html.md
@@ -68,11 +68,11 @@ makes it easier - first, `async.waterfall`
 function transformFile(inPath, outPath, done) {
 	async.waterfall([
 		function(callback) { 
-			fs.readFile(file1, 'utf8', callback); },	
+			fs.readFile(inPath, 'utf8', callback); },	
 		function(data, callback) { 
 			service.transform(data, callback); },
 		function(transformed, callback) { 
-			fs.writeFile(transformed, callback); }
+			fs.writeFile(outPath, transformed, callback); }
 	], done);
 }
 ``` 


### PR DESCRIPTION
- Added missing argument outPath in async waterfall example in Notes
- Corrected argument name file1 to inPath in async waterfall example in Notes