### PR TITLE
13-complex-task-dependencies: Add ES2015 object destructuring syntax

### DIFF
--- a/src/documents/articles/13-complex-task-dependencies.html.md
+++ b/src/documents/articles/13-complex-task-dependencies.html.md
@@ -57,17 +57,15 @@ files.getLastTwoVersions(filename)
 ## Notes
 
 Instead of using `.spread`, the well known `.then` can still be used 
-using ES2015 object destructuring:
+using ES2015 array destructuring:
 
 ```js
 files.getLastTwoVersions(filename)
     .then(function(items) {
-        return {
-            v1: versions.get(items.last), 
-            v2: versions.get(items.previous)
-        };
+        return [versions.get(items.last),
+        	    versions.get(items.previous)];
     })
-    .then(function({v1, v2}) { 
+    .then(function([v1, v2]) { 
         return diffService.compare(v1.blob, v2.blob)
     })
     .then(function(diff) {

--- a/src/documents/articles/13-complex-task-dependencies.html.md
+++ b/src/documents/articles/13-complex-task-dependencies.html.md
@@ -56,4 +56,21 @@ files.getLastTwoVersions(filename)
 
 ## Notes
 
-TODO.
+Instead of using `.spread`, the well known `.then` can still be used 
+using ES2015 object destructuring:
+
+```js
+files.getLastTwoVersions(filename)
+    .then(function(items) {
+        return {
+            v1: versions.get(items.last), 
+            v2: versions.get(items.previous)
+        };
+    })
+    .then(function({v1, v2}) { 
+        return diffService.compare(v1.blob, v2.blob)
+    })
+    .then(function(diff) {
+        // voila, diff is ready. Do something with it.
+    });
+```


### PR DESCRIPTION
as an alternative for the `Promise.spread` example

Reference: https://github.com/promise-nuggets/promise-nuggets.github.io/issues/13 (Need to make tutorial ES6-compatible)

Not sure if I should also convert to arrow function syntax?
