### PR TITLE
make npm start work on windows commandline

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "docpad-plugin-eco": "*",
     "docpad-plugin-marked": "*"
   },
-  "main": "node_modules/docpad/bin/docpad-server",
+  "main": "docpad-server",
   "scripts": {
-    "start": "node_modules/docpad/bin/docpad-server"
+    "start": "docpad-server"
   }
 }


### PR DESCRIPTION
I guess this should still work on linux/mac?

Error I got was:

```
> no-skeleton.docpad@0.1.0 start C:\temp\promise-nuggets
> node_modules/docpad/bin/docpad-server

'node_modules' is not recognized as an internal or external command,
operable program or batch file.
```
